### PR TITLE
Allow all Exceptions when importing optional modules

### DIFF
--- a/birdseye/bird.py
+++ b/birdseye/bird.py
@@ -40,13 +40,13 @@ from birdseye import __version__
 
 try:
     from numpy import ndarray
-except ImportError:
+except Exception:
     class ndarray(object):
         pass
 
 try:
     from pandas import DataFrame, Series
-except ImportError:
+except Exception:
     class DataFrame(object):
         pass
 
@@ -56,7 +56,7 @@ except ImportError:
 
 try:
     from django.db.models import QuerySet
-except ImportError:
+except Exception:
     class QuerySet(object):
         pass
 


### PR DESCRIPTION
Importing a module may fail with other exceptions besides ImportError, eg. with OSError when the module is present in user site packages but for wrong architecture.

Here is an example case which would be solved by this PR: https://github.com/thonny/thonny/issues/1141